### PR TITLE
Fix importConfig recommendation length bug

### DIFF
--- a/server/controller/config.js
+++ b/server/controller/config.js
@@ -151,7 +151,7 @@ module.exports.importConfig = async (obj) => {
         await config.update({value: validate.value}, {where: {key: key}});
     }
 
-    if (recommendations.length > 1) return false;
+    if (obj.recommendations.length > 1) return false;
 
     await node.destroy({where: {}});
     await recommendations.destroy({where: {}});


### PR DESCRIPTION
## Summary
- fix typo in `importConfig` that referenced the wrong variable when checking recommendation count

## Testing
- `npm install`
- `NODE_ENV=test node server/index.js` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_684a60f37e8c8333b0c9b85e61d18926